### PR TITLE
stdin/stdout versions of tokenizer and detokenizer. breaks python2 co…

### DIFF
--- a/src/indicnlp/tokenize/indic_detokenize.py
+++ b/src/indicnlp/tokenize/indic_detokenize.py
@@ -22,6 +22,7 @@
 # @author Anoop Kunchukuttan 
 #
 
+import argparse
 import string, re, sys, codecs
 
 from indicnlp.common import IndicNlpException
@@ -111,10 +112,15 @@ if __name__ == '__main__':
 
     if len(sys.argv)<4:
         print("Usage: python indic_detokenize.py <infile> <outfile> <language>")
+        print("       Set file to - for stdin/stdout")
         sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("infile", type = argparse.FileType('r', encoding="utf8"),  metavar='INFILE')
+    parser.add_argument("outfile", type = argparse.FileType('w', encoding="utf8"),  metavar='OUTFILE')
+    parser.add_argument("language", metavar='LANGUAGE')
+    args = parser.parse_args()
 
-    with codecs.open(sys.argv[1],'r','utf-8') as ifile:
-        with codecs.open(sys.argv[2],'w','utf-8') as ofile:
-            for line in ifile:
-                detokenized_line=trivial_detokenize(line,sys.argv[3])
-                ofile.write(detokenized_line)
+
+    for line in args.infile:
+        detokenized_line=trivial_detokenize(line,args.language)
+        args.outfile.write(detokenized_line)

--- a/src/indicnlp/tokenize/indic_tokenize.py
+++ b/src/indicnlp/tokenize/indic_tokenize.py
@@ -1,4 +1,3 @@
-
 # Copyright Anoop Kunchukuttan 2014 - present
 #
 # This file is part of Indic NLP Library.
@@ -22,6 +21,7 @@
 # @author Anoop Kunchukuttan 
 #
 
+import argparse
 import string, re, sys, codecs
 
 from indicnlp.common import IndicNlpException
@@ -82,10 +82,14 @@ if __name__ == '__main__':
 
     if len(sys.argv)<4:
         print("Usage: python indic_tokenize.py <infile> <outfile> <language>")
+        print("       Set file to - for stdin/stdout")
         sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("infile", type = argparse.FileType('r', encoding="utf8"),  metavar='INFILE')
+    parser.add_argument("outfile", type = argparse.FileType('w', encoding="utf8"),  metavar='OUTFILE')
+    parser.add_argument("language", metavar='LANGUAGE')
+    args = parser.parse_args()
 
-    with codecs.open(sys.argv[1],'r','utf-8') as ifile:
-        with codecs.open(sys.argv[2],'w','utf-8') as ofile:
-            for line in ifile:
-                tokenized_line=' '.join(trivial_tokenize(line,sys.argv[3]))
-                ofile.write(tokenized_line)
+    for line in args.infile:
+        tokenized_line=' '.join(trivial_tokenize(line,args.language))
+        args.outfile.write(tokenized_line)


### PR DESCRIPTION
…mpatibility

This updates the tokenizer and detokenizer so that they can read/write from stdin/stdout. To do this, just use a dash (-) for the filename. 

It breaks python2 compatibility. If this is a problem, then I could find a workaround, but it may be messy.