### PR TITLE
make sphinx an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ The data resources required by the Indic NLP Library are hosted in a different r
 - If you want to use the project from the github repo, add the project to the Python Path: 
 
     - Clone this repository
-    - Install dependencies: `pip install -r requirements.txt`
-    - Run: `export PYTHONPATH=$PYTHONPATH:<project base directory>`
+    - Install `indicnlp` and its dependencies: `pip install -e '.[dev]'`
 
 - In either case, export the path to the _Indic NLP Resources_ directory
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-sphinx-argparse
-sphinx_rtd_theme
 morfessor
 pandas
 numpy

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,8 @@ setuptools.setup(
     install_requires=[
         str(requirement) for requirement
             in parse_requirements(pathlib.Path('requirements.txt').open())
-    ]
+    ],
+    extras_require = {
+        "dev": ["sphinx-argparse", "sphinx_rtd_theme"],
+    }
 )


### PR DESCRIPTION
Hi, thanks for this great library.

With this PR users will get faster installation speed..

I noticed that during the installation, `indicnlp` is pulling sphinx and a lot of modules which are only needed for working on the documentation, not for using the library itself.
I recommend marking those depencies as "extra". To install them you'll only need to run `pip install -e '.[dev]'` to install the library locally and work on the documentation.
Note that doing `pip install -e .` works better with python virtual environments than modifying PYTHONPATH.
