### PR TITLE
Added version.txt file to package_data in call to setuptools.setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
     #     "Source Code": "https://code.example.com/HelloWorld/",
     # },    
     packages=setuptools.find_packages(),
+    package_data={'indicnlp': ['version.txt']},
     license='MIT',
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This is necessary so that the setup.py script so is discoverable after pip installation. Otherwise, programs like conda forge's setup scripts that run setup.py during package installation will error out.

Please see #63 for more context.

@anoopkunchukuttan I would appreciate if you could merge this and publish to Pypi ASAP so that I can make this available via conda forge. Thank you.