### PR TITLE
Modified sentence_tokenize to handle tokeniztion of sentence which ends with numerics.

### DIFF
--- a/indicnlp/tokenize/sentence_tokenize.py
+++ b/indicnlp/tokenize/sentence_tokenize.py
@@ -234,7 +234,7 @@ def sentence_split(text,lang,delim_pat='auto'): ## New signature
         p2=mo.end()
         
         ## NEW
-        if p1>0 and text[p1-1].isnumeric():
+        if (p1>0 and text[p1-1].isnumeric()) and (p1+1 < len(text) and text[p1+1].isnumeric()):
             continue
         
         ## Prevents splitting on "." in URLs/emails in indic texts.


### PR DESCRIPTION
Previously the sentence was not able to tokenize the sentence, if the sentence ends with numeric character which i guess was a logic issue for checking and not splitting for decimal number.
I have changed logic a bit, specifically for not tokenizing in that condition.
So for the sentence - "India was declared a nation with its own constitution on 26 January 1950, while India gained independence on 14 August 1947. About 3 years went through the formation of the nation and the complete departure of the British." it's working fine also tested a few edge cases too.